### PR TITLE
Set linux file permissions on downloading as well as on game start, should fix file permissions issue

### DIFF
--- a/src/main/kotlin/ga/rubydesic/dmd/DynamicMusicDiscsMod.kt
+++ b/src/main/kotlin/ga/rubydesic/dmd/DynamicMusicDiscsMod.kt
@@ -151,12 +151,7 @@ fun downloadYtDlBinary() {
     val path = dir.resolve(if (SystemUtils.IS_OS_WINDOWS) "youtube-dl.exe" else "youtube-dl").toAbsolutePath()
     if (Files.exists(path)) {
         log.info("youtube-dl binary already exists")
-        try {
-            Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rwxrwxrwx"));
-            log.info("Made youtube-dl binary executable")
-        } catch (ex: Exception) {
-            log.info("Failed to make youtube-dl binary executable...", ex)
-        }
+        setYTDLPermission(path)
 
         log.info("Running youtube-dl --update")
         ytdlBinaryFuture = GlobalScope.async(Dispatchers.IO) {
@@ -181,9 +176,19 @@ fun downloadYtDlBinary() {
             }
 
             log.info("Finished downloading youtube-dl binary")
+            setYTDLPermission(path)
             path
         }
 
+    }
+}
+
+fun setYTDLPermission(path: Path){
+    try {
+        Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rwxrwxrwx"));
+        log.info("Made youtube-dl binary executable")
+    } catch (ex: Exception) {
+        log.info("Failed to make youtube-dl binary executable...", ex)
     }
 }
 


### PR DESCRIPTION
I've been doing some work trying to make this work on my game, which is on linux. There are other changes I've been making but this one is pretty trivial and could be included straight away - it's just including the file permissions set function after youtube-dl is downloaded where it was previously missing as well as checking on game start.

It should fix the file permission error 13 people have been seeing in issue #1 and mentioning in other issues.